### PR TITLE
Fail while trying to find sudo.bat on windows.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -172,7 +172,7 @@ export const installer = (Sys.installer = function (
         if (cmd.includes('choco') && isWindows()) {
             cmd = where('choco') ?? 'choco';
             system = [cmd].concat(system);
-            cmd = join(__dirname, 'bin', 'sudo.bat');
+            cmd = join(__dirname, '..', 'bin', 'sudo.bat');
         }
 
         return spawning(cmd, system, progress);
@@ -261,7 +261,7 @@ export const spawning = (Sys.spawning = function (
 
             // sudo
             if (isWindows()) {
-                command = join(__dirname, 'bin', 'sudo.bat');
+                command = join(__dirname, '..', 'bin', 'sudo.bat');
             } else {
                 command = sudo;
             }


### PR DESCRIPTION
Basically the programs errors out when it tries to access the file on windows cause it looks in `join(__dirname, 'bin', 'sudo.bat')` which resolves to `dist\\bin\\sudo.bat`. Now because I added `..` it goes back 1 folder level and resolves correctly into `\\bin\\sudo.bat`.